### PR TITLE
[Rhasspy] Https improvements

### DIFF
--- a/rhasspy/config.json
+++ b/rhasspy/config.json
@@ -28,6 +28,10 @@
     "12101/tcp": 12101,
     "12333/udp": 12333
   },
+  "ports_description": {
+    "12101/tcp": "Rhasspy Web UI + API",
+    "12333/udp": "Port for HTTP POST audio stream input"
+  },
   "schema": {
     "profile_dir": "str",
     "profile_name": "str",

--- a/rhasspy/config.json
+++ b/rhasspy/config.json
@@ -32,10 +32,10 @@
     "profile_dir": "str",
     "profile_name": "str",
     "ssl": "bool",
-    "certfile": "str",
-    "keyfile": "str",
+    "certfile": "match(^[^/].*)",
+    "keyfile": "match(^[^/].*)",
     "asoundrc": "str"
   },
   "homeassistant_api": true,
-  "webui": "http://[HOST]:[PORT:12101]/"
+  "webui": "[PROTO:ssl]://[HOST]:[PORT:12101]/"
 }


### PR DESCRIPTION
* Adds protocol switch on webui path depending on `ssl` toggle.
* Adds matcher for the certificate settings, which checks that the first char is _not_ a `/` (like in `/ssl`)
* Adds descriptions for the ports

Hint: If the urls of Rhasspy would be relative the [Home Assistant Ingress](https://developers.home-assistant.io/docs/add-ons/presentation/#ingress) could be used.